### PR TITLE
[Step11&12]

### DIFF
--- a/docs/Week6ConcurrecyControlReport.md
+++ b/docs/Week6ConcurrecyControlReport.md
@@ -1,0 +1,393 @@
+# 1. 동시성 문제
+<details>  
+<summary>항해 1, 2주차에 동시성 문제에 대해 찾아본 내용을 다시 정리해보면</summary>
+
+- 동시성 문제는 **여러 Process나 Thread가 동시에 자원에 접근하거나 작업을 수행할 때 발생할 수 있는 예기치 않은 문제**입니다.
+- 이 떄, 동시성 문제를 고려하는 맥락(공유 자원, 임계 구역)이 중요합니다.
+---
+### JVM 환경에서 동시성 문제가 발생하는 맥락을 살펴보면, 다음과 같습니다.
+  - 멀티 코어 환경에서 Thread 사용 시, 코어 당 하나의 Thread 처리합니다.
+    Thread는 STACK만 분리하고, HEAP, CODE, DATA 영역은 공유하며,
+    따라서 HEAP, DATA에 적재된 자원에 대해서 동시성 문제가 발생하게 됩니다.
+  - JVM 은 단일 프로세스로 실행되지만 기본적으로 멀티 Threading 활용할 수 있으며,
+    이 때, JVM Thread와 OS Thread를 매핑하는 방식인 
+    Threading 모델 *(=OS Thread와 매핑하는 방식)* 은 JVM마다 차이가 있을 수 있습니다.
+---
+### Spring + Web Application 에서 발생하는 동시성 문제가 발생하는 맥락을 살펴보면, 다음과 같습니다.
+  - Spring 은 요청마다 Thread를 생성 또는 할당하는 방식을 사용합니다. 
+    그리고 통상적으로 Web Application은 별도의 스토리지(ex. RDB)에 데이터를 적재하며,
+    이 때, 특정 데이터에 대해 여러 요청이 CRUD 하는 과정에서 동시성 문제가 발생할 수 있습니다.
+  - 단일 서버 환경이라면 Application 내에서 동시성 문제를 제어할 수 있겠지만,
+    분산 서버 환경에서는 Database 에서 제공하는 기능들을 활용해 동시성 문제를 제어하게 됩니다.
+---
+### Database 에서 발생할 수 있는 동시성 문제를 살펴보면, 다음과 같습니다. (위키피디아 [참고](https://en.wikipedia.org/wiki/Concurrency_control))
+  - lost update problem (=overwriting uncommited data)
+    - 1번, 2번 트랜잭션이 각각 A 데이터에 쓰기 작업을 하고, B 데이터에 쓰기 작업을 하는 경우, 
+      (A1, B1) (A1, B2) (A2, B1) (A2, B2) 의 경우로 끝나는 상황이 발생할 수 있음
+    ```
+    Tx1 : T1.start() → Update(A v1) → Update(B v1) → T1.commit()
+    Tx2 : T2.start() → Update(B v2) → Update(B v2) → T2.commit()
+    - expected : A v1 & B v1 또는 A v2 & B v2
+    - failed : A v2 & B v1 또는 A v1 & B v2
+    ```
+  - dirty read problem (reading uncommited data)
+    - 1번, 2번 트랜잭션이 각각 A 데이터를 조회해서 A 데이터를 변경하는 경우,
+      (T1만 적용됨) (T1 T2가 적용됨) (T2가 적용됨) 의 경우로 끝나는 상황이 발생할 수 있음
+    ```
+    Tx1 : T1.start() → Read(A) → Update(A v1) → Read(B) → Update(B v1) → T1.commit()
+    Tx2 : T2.start() → Read(A) → Update(A v2) → Read(B) → Update(B v2) → T2.commit()
+    - expected : Read(A) → A v0 / Read(B) → B v0
+    - failed : Read(A) → A v1 또는 A v2 / Read(B) → B v1 또는 B v2
+    ```
+  - incorrect summary problem (= inconsistency analysis)
+    - summary 하는 트랜잭션이 진행 중인데 update 가 일어나 summary 값이 일관되지 않는 문제
+  - Uncommitted Dependency : 
+    - Rollback 된 데이터를 Rollback 전에 읽어 생기는 문제
+</details>
+
+## 1-1. Database 동시성 문제 톺아보기
+- MySQL READ COMMITED 로 변경했을 때 트랜잭션 내에서 동일 쿼리의 결과가 달라지는 것을 확인할 수 있습니다.
+<details>
+<summary>SQL 문 확인하기</summary>
+
+```sql
+# Phantom Read @ MySQL 8.0.40
+# 격리수준을 READ COMMITTED 로 변경하고 INSERT 한 경우
+
+#given
+Tx1 : SET TRANSACTION ISOLATION LEVEL READ COMMITTED ;
+Tx1 : START TRANSACTION ;
+
+Tx2 : SET TRANSACTION ISOLATION LEVEL READ COMMITTED ;
+Tx2 : START TRANSACTION ;
+
+#when
+Tx1 : SELECT * FROM data ; #then : data 1건 조회
+Tx2 : INSERT INTO DATA (~) VALUES (~) ;
+Tx2 : COMMIT ;
+
+Tx1 : SELECT * FROM data ; #then : data 2건 조회
+Tx1 : COMMIT ;
+```
+
+```sql
+#Phantom Read @ MySQL 8.0.40
+#격리수준을 READ COMMITTED 로 변경하고 DELETE 한 경우
+
+#given
+Tx1 : SET TRANSACTION ISOLATION LEVEL READ COMMITTED ;
+Tx1 : START TRANSACTION ;
+
+Tx2 : SET TRANSACTION ISOLATION LEVEL READ COMMITTED ;
+Tx2 : START TRANSACTION ;
+
+#when
+Tx1 : SELECT * FROM data ; #then : data 1건 조회
+Tx2 : DELETE FROM data ;
+Tx2 : COMMIT ;
+
+Tx1 : SELECT * FROM data ; #then : data 2건 조회
+Tx1 : COMMIT ;
+```
+</details>
+
+- 추가로, MySQL 에서도 특수한 경우에 Phantom Read가 발생하는 것을 확인할 수 있습니다.
+
+<details>
+<summary>SQL 문 확인하기</summary>
+
+```sql
+# Phantom Read @ MySQL 8.0.40
+# REPEATABLE READ 에서도 Phantom Read 가 발생할 수 있는 경우
+# [참고] https://velog.io/@glencode/트랜잭션과-ACID-그리고-MySQL-InnoDB에서-Phantom-Read
+
+# SELECT @@GLOBAL.transaction_isolation; #REPEATABLE_READ
+# SELECT @@SESSION.transaction_isolation; #REPEATABLE_READ
+
+Tx1 : START TRANSACTION ;
+Tx2 : START TRANSACTION ;
+
+Tx2 : SELECT * FROM data ;
+
+Tx1 : INSERT INTO data VALUES (1, '종협 코치님', 31) ;
+Tx1 : COMMIT ;
+
+Tx2 : SELECT * FROM data ; #안 보임 : MVCC 로 Phantom Read 가 발생하지 않음
+
+# 아래 구문 모두 Tx1의 영향을 받음
+# Case 1 : 조회는 여전히 불가
+Tx2 : INSERT INTO data VALUES (1, '허재 코치님', 30); # 대기하다가 commit 되면 Duplicate Key
+Tx2 : DELETE FROM data WHERE id = 1; # 1 rows affected. 조회 불가
+
+Tx2 : SELECT * FROM data FOR SHARE; # Phantom Read 발생
+Tx2 : SELECT * FROM data FOR UPDATE; # Phantom Read 발생 
+
+# Case 2 : 조회 결과 변경됨
+Tx2 : UPDATE data SET age = '32' where name = '종협 코치님'; #then 1 update : Phantom!?!
+Tx2 : SELECT * FROM data ; #update 후 보임 : Phantom Read 발생
+
+Tx2 : COMMIT ;
+```
+</details>
+
+# 2. 동시성 제어
+
+- 동시성 제어를 위해 락을 사용하는 방법에는 낙관락, 비관락, 분산락 등이 있습니다. ([참고](https://velog.io/@dangddoong/learning-solutions-concurrency-issues-e-commerce-inventory-management-logic))
+- 비관적 락
+  - Database 차원에서 제공하며, 실패 시 DB단 에러 확인 가능합니다.
+  - 공유락 (=S-Lock, Shared Lock) 과 배타락 (=X-Lock, Exclusive Lock)이 있으며,
+    공유락은 `SELECT ~ FOR SHARE` 구문을, 배타락은 `SELECT ~ FOR UPDATE` 구문으로 획득할 수 있습니다.
+  - 공유락이 걸린 데이터는 해당 데이터를 결과에 포함하는 `SELECT` 와 `SELECT ~ FOR SHARE`은 허용하지만 `SELECT ~ FOR UPDATE`은 대기하게 합니다.
+  - 배타락이 걸린 데이터는 해당 데이터를 결과에 포함하는 `SELECT`는 허용하지만 `SELECT ~ FOR SHARE` 와 `SELECT ~ FOR UPDATE`는 대기하게 합니다.
+  - 추가로 테이블에 락을 거는 경우 `LOCK TABLE ~ READ` 구문과 `LOCK TABLE ~ WRITE` 구문을 사용할 수 있습니다.
+- 낙관적 락 : Version 용 컬럼을 통해 동시성을 제어하는 방안 → 실패 시 DB에서는 0 rows affected
+    - 테이블 내부에 버전관리 만을 위한 필드가 추가됨
+    ```sql
+    # 2번 낙관적 락
+    T1 -> SELECT * FROM users WHERE userId = 1;
+    T2 -> SELECT * FROM users WHERE userId = 1;
+    T1 -> UPDATE users SET point = 700, version = 1 WHERE userId = 1 AND version = 0;
+    T1 COMMIT;
+    # T1 은 성공!
+
+    T2 -> UPDATE users SET point = 1000, version = 1 WHERE userId = 1 AND version = 0;
+    # DB에서 return 0
+
+    # Spring Data 단에서 Update 0 이라 ObjectOptimisticLockingFailureException 발생
+    # 재시도 처리하거나 오류나서 Rollback 되거나 하도록 Application 단에서 제어
+    ```
+
+- 별개로, Named Query와 `@Modifying`을 활용해 DB단 원자적 연산을 보장하는 방법이 있으나, 도메인의 정책과 기능이 DB에 의존적이게 된다는 단점이 있습니다.
+    - [참고1](https://velog.io/@dangddoong/%EC%87%BC%ED%95%91%EB%AA%B0-%EC%9E%AC%EA%B3%A0%EA%B4%80%EB%A6%AC-%EB%8F%99%EC%8B%9C%EC%84%B1-%EB%AC%B8%EC%A0%9C-Query%EB%A1%9C-%ED%95%B4%EA%B2%B0%ED%95%98%EA%B8%B0-Lock-%EA%B5%AC%EA%B0%84%EC%9D%84-%EC%B5%9C%EC%86%8C%ED%99%94%ED%95%98%EA%B8%B0)
+    - [참고2](https://frogand.tistory.com/174)
+
+# 3.시나리오 분석
+- 동시성 문제가 발생 가능한 시나리오
+1. 쿠폰 도메인
+    1. 쿠폰 발급 : 여러 사람이 하나의 자원(CouponTemplate)에 접근 가능. **배타적 락 사용**
+        - 선착순 쿠폰이라는 점에 있어서 요청이 몰릴 가능성이 높음. 대기열 or 분산 락을 고려해볼만 함.
+        - 예상
+            1. CouponTemplate 조회
+            2. CouponTemplate 변경
+            3. IssuedCoupon 생성
+        - 실제
+            1. CouponTemplate 조회
+            2. IssuedCoupon 생성
+            3. CouponTemplate 변경 (⇒ Dirty Checking)
+            <details>
+            <summary>테스트 코드 실행 결과</summary>
+
+                ```sql
+                # 쿠폰 최대 발급 개수가 10개이고, 쿠폰 발급 요청이 20건 들어왔을 때, 10건만 성공한다
+                # 실행되는 결과를 보니 Pool Size 가 3개인가? 했음... -> 맞음...
+                (S1) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S2) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S3) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (I1) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (U1) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I2) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S4) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U2) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I3) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S5) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U3) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I4) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S6) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U4) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I5) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S7) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U5) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I6) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S8) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U6) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I7) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S9) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U7) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I8) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S10) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U8) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I9) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S11) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U9) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I10) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S12) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U10) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (S13) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S14) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S15) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S16) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S17) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S18) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S19) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S20) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                
+                ```
+
+                ```sql
+                # 쿠폰 최대 발급 개수가 10개이고, 쿠폰 발급 요청이 20건 들어왔을 때, 10건만 성공한다
+                # Maximum Pool Size 10개이면...
+                
+                (S01) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S02) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S03) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S04) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S05) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S06) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S07) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S08) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S09) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (S10) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (I01) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (U01) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I02) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (U02) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (S11) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (I03) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S12) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U03) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I04) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S13) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U04) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I05) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S14) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U05) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I06) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S15) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U06) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I07) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S16) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U07) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I08) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S17) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U08) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I09) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S18) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U09) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (I10) Hibernate: insert into issued_coupon (created_at,expires_at,owned_by,template_id,updated_at,used_at) values (?,?,?,?,?,?)
+                (S19) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                (U10) Hibernate: update coupon_template set created_at=?,discount_rate=?,issuable_until=?,issue_count=?,max_issue_count=?,updated_at=? where id=?
+                (S20) Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=? for update
+                
+                ```
+            </details>
+    2. 쿠폰 사용 : 한 사람이 하나의 자원(IssuedCoupon)에 접근. **낙관적 락 사용**
+        - 예상
+            1. IssuedCoupon 조회
+            2. IssuedCoupon 변경
+        - 실제
+            1. IssuedCoupon 조회
+            2. CouponTemplate 조회
+            3. IssuedCoupon 변경
+          <details>
+            <summary>테스트 코드 실행 결과</summary>
+          
+                ```sql
+                # 쿠폰 사용 요청이 2건 이상 들어왔을 때, 1건만 성공한다
+                # FetchType.LAZY 이고 Connection Pool 1개 이면
+                Hibernate: select ic1_0.id,ic1_0.created_at,ic1_0.expires_at,ic1_0.owned_by,ic1_0.template_id,ic1_0.updated_at,ic1_0.used_at from issued_coupon ic1_0 where ic1_0.id=? for update
+                Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=?
+                Hibernate: update issued_coupon set created_at=?,expires_at=?,owned_by=?,template_id=?,updated_at=?,used_at=? where id=?
+                Hibernate: select ic1_0.id,ic1_0.created_at,ic1_0.expires_at,ic1_0.owned_by,ic1_0.template_id,ic1_0.updated_at,ic1_0.used_at from issued_coupon ic1_0 where ic1_0.id=? for update
+                Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=?
+                ```
+
+                ```sql
+                # FetchType.EAGER 이고 Connection Pool 1개 이면
+                Hibernate: select ic1_0.id,ic1_0.created_at,ic1_0.expires_at,ic1_0.owned_by,ic1_0.template_id,ic1_0.updated_at,ic1_0.used_at from issued_coupon ic1_0 where ic1_0.id=? for update
+                Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=?
+                Hibernate: update issued_coupon set created_at=?,expires_at=?,owned_by=?,template_id=?,updated_at=?,used_at=? where id=?
+                Hibernate: select ic1_0.id,ic1_0.created_at,ic1_0.expires_at,ic1_0.owned_by,ic1_0.template_id,ic1_0.updated_at,ic1_0.used_at from issued_coupon ic1_0 where ic1_0.id=? for update
+                Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=?
+                ```
+
+                ```sql
+                # 왜 CouponTemplate을 계속 가져오지? Proxy 객체가 아니네?
+                # Transactional 때문인가? -> select 중에 오류 발생
+                # Lock 때문인가? -> 
+                Hibernate: select ic1_0.id,ic1_0.created_at,ic1_0.expires_at,ic1_0.owned_by,ic1_0.template_id,ic1_0.updated_at,ic1_0.used_at from issued_coupon ic1_0 where ic1_0.id=? for update
+                Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=?
+                2025-01-23T05:41:27.334Z  INFO 29828 --- [hhplus] [pool-2-thread-1] k.h.b.s.domain.coupon.CouponService      : class kr.hhplus.be.server.domain.coupon.model.IssuedCoupon
+                2025-01-23T05:41:27.334Z  INFO 29828 --- [hhplus] [pool-2-thread-1] k.h.b.s.domain.coupon.CouponService      : class kr.hhplus.be.server.domain.coupon.model.CouponTemplate
+                Hibernate: update issued_coupon set created_at=?,expires_at=?,owned_by=?,template_id=?,updated_at=?,used_at=? where id=?
+                Hibernate: select ic1_0.id,ic1_0.created_at,ic1_0.expires_at,ic1_0.owned_by,ic1_0.template_id,ic1_0.updated_at,ic1_0.used_at from issued_coupon ic1_0 where ic1_0.id=? for update
+                Hibernate: select ct1_0.id,ct1_0.created_at,ct1_0.discount_rate,ct1_0.issuable_until,ct1_0.issue_count,ct1_0.max_issue_count,ct1_0.updated_at from coupon_template ct1_0 where ct1_0.id=?
+                2025-01-23T05:41:27.427Z  INFO 29828 --- [hhplus] [pool-2-thread-2] k.h.b.s.domain.coupon.CouponService      : class kr.hhplus.be.server.domain.coupon.model.IssuedCoupon
+                2025-01-23T05:41:27.428Z  INFO 29828 --- [hhplus] [pool-2-thread-2] k.h.b.s.domain.coupon.CouponService      : class kr.hhplus.be.server.domain.coupon.model.CouponTemplate
+                
+                ```
+            </details>
+2. 상품
+    1. 재고 차감 : 여러 사람이 하나의 자원(Product)에 접근 가능. **배타적 락 사용**
+        - 예상
+            1. Product 조회
+            2. Product 변경
+        - 실제
+            1. Product 조회
+            2. Product 변경
+            <details>
+            <summary>테스트 코드 실행 결과</summary>
+
+                ```sql
+                # 상품 재고 요청이 5건 들어왔을 때, 요청 내용만큼 재고가 차감된다
+                Hibernate: select p1_0.id,p1_0.created_at,p1_0.name,p1_0.remaining_quantity,p1_0.unit_price,p1_0.updated_at from product p1_0 limit ?,?
+                
+                # 테스트 범위
+                (S01) Hibernate: select p1_0.id,p1_0.created_at,p1_0.name,p1_0.remaining_quantity,p1_0.unit_price,p1_0.updated_at from product p1_0 where p1_0.id=? for update
+                (S02) Hibernate: select p1_0.id,p1_0.created_at,p1_0.name,p1_0.remaining_quantity,p1_0.unit_price,p1_0.updated_at from product p1_0 where p1_0.id=? for update
+                (U01) Hibernate: update product set created_at=?,name=?,remaining_quantity=?,unit_price=?,updated_at=? where id=?
+                (U02) Hibernate: update product set created_at=?,name=?,remaining_quantity=?,unit_price=?,updated_at=? where id=?
+                (S03) Hibernate: select p1_0.id,p1_0.created_at,p1_0.name,p1_0.remaining_quantity,p1_0.unit_price,p1_0.updated_at from product p1_0 where p1_0.id=? for update
+                (U03) Hibernate: update product set created_at=?,name=?,remaining_quantity=?,unit_price=?,updated_at=? where id=?
+                (S04) Hibernate: select p1_0.id,p1_0.created_at,p1_0.name,p1_0.remaining_quantity,p1_0.unit_price,p1_0.updated_at from product p1_0 where p1_0.id=? for update
+                (U04) Hibernate: update product set created_at=?,name=?,remaining_quantity=?,unit_price=?,updated_at=? where id=?
+                (S05) Hibernate: select p1_0.id,p1_0.created_at,p1_0.name,p1_0.remaining_quantity,p1_0.unit_price,p1_0.updated_at from product p1_0 where p1_0.id=? for update
+                (U05) Hibernate: update product set created_at=?,name=?,remaining_quantity=?,unit_price=?,updated_at=? where id=?
+                
+                Hibernate: select p1_0.id,p1_0.created_at,p1_0.name,p1_0.remaining_quantity,p1_0.unit_price,p1_0.updated_at from product p1_0 limit ?,?
+                
+                ```
+            </details>
+
+3. 포인트 : 한 사람이 하나의 자원(Point)에 접근. **낙관적 락 사용**
+    1. 포인트 충전
+        - 포인트 조회
+        - 포인트 변경
+    2. 포인트 차감
+        - 포인트 조회
+        - 포인트 변경
+    3. 포인트 충전 & 차감
+        - 포인트 조회
+        - 포인트 변경
+
+        <details>
+        <summary>테스트 코드 실행 결과</summary>
+   
+        ```sql
+        (S01) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (S02) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (S03) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (U01) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        (U02) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        (S04) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (U03) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        (S05) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (U04) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        (S06) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (U05) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        (S07) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (U06) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        (S08) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (U07) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        (S09) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (U08) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        (S10) Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        (U09) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        (U10) Hibernate: update point set balance=?,created_at=?,updated_at=?,user_id=? where id=?
+        
+        Hibernate: select p1_0.id,p1_0.balance,p1_0.created_at,p1_0.updated_at,p1_0.user_id from point p1_0 where p1_0.user_id=? for update
+        ```
+        </details>
+
+## 3-1. 시나리오별 동시성 제어 방안
+- 1명의 사용자(=사람)는 악의를 가진 게 아닌 이상 동시에 작업을 요청할 가능성이 낮다고 가정했습니다.
+- 따라서 쿠폰 사용 및 포인트 충전/차감은 낙관적 락으로, 쿠폰 발급 및 재고 차감은 비관적(배타적) 락으로 대응할 예정입니다.

--- a/src/main/kotlin/kr/hhplus/be/server/domain/coupon/model/IssuedCoupon.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/coupon/model/IssuedCoupon.kt
@@ -3,6 +3,7 @@ package kr.hhplus.be.server.domain.coupon.model
 import jakarta.persistence.*
 import kr.hhplus.be.server.common.exception.CustomException
 import kr.hhplus.be.server.common.exception.CustomExceptionType
+import org.hibernate.annotations.ColumnDefault
 import java.time.LocalDateTime
 
 @Entity
@@ -16,6 +17,9 @@ class IssuedCoupon(
     var usedAt: LocalDateTime?,
     val createdAt: LocalDateTime = LocalDateTime.now(),
     val updatedAt: LocalDateTime = LocalDateTime.now(),
+    @Version
+    @ColumnDefault("0")
+    val version: Long = 0L,
 ) {
     fun getStatus(at: LocalDateTime = LocalDateTime.now()): CouponStatus {
         if (usedAt != null) {

--- a/src/main/kotlin/kr/hhplus/be/server/domain/point/model/Point.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/domain/point/model/Point.kt
@@ -4,8 +4,10 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Version
 import kr.hhplus.be.server.common.exception.CustomException
 import kr.hhplus.be.server.common.exception.CustomExceptionType
+import org.hibernate.annotations.ColumnDefault
 import java.time.LocalDateTime
 
 @Entity
@@ -16,7 +18,10 @@ class Point(
     var balance: Int = 0,
     val createdAt: LocalDateTime = LocalDateTime.now(),
     val updatedAt: LocalDateTime = LocalDateTime.now(),
-    ) {
+    @Version
+    @ColumnDefault("0")
+    val version: Long = 0,
+) {
 
     companion object {
         val MIN_BALANCE = 0

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/IssuedCouponJpaRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/IssuedCouponJpaRepository.kt
@@ -10,5 +10,9 @@ import org.springframework.stereotype.Repository
 interface IssuedCouponJpaRepository : JpaRepository<IssuedCoupon, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findForUpdateById(id: Long): IssuedCoupon?
+
+    @Lock(LockModeType.OPTIMISTIC)
+    fun findWithOptimisticLockById(id: Long): IssuedCoupon?
+
     fun findIssuedCouponsByOwnedBy(userId: Long): List<IssuedCoupon>
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/IssuedCouponRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/coupon/IssuedCouponRepositoryImpl.kt
@@ -10,7 +10,8 @@ class IssuedCouponRepositoryImpl @Autowired constructor(
     private val issuedCouponJpaRepository: IssuedCouponJpaRepository,
 ) : IssuedCouponRepository {
     override fun findIssuedCouponByIdWithLock(id: Long): IssuedCoupon? {
-        return issuedCouponJpaRepository.findForUpdateById(id)
+//        return issuedCouponJpaRepository.findForUpdateById(id)
+        return issuedCouponJpaRepository.findWithOptimisticLockById(id)
     }
 
     override fun findIssuedCouponsByUserId(userId: Long): List<IssuedCoupon> {

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/PointJpaRepository.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/PointJpaRepository.kt
@@ -10,4 +10,7 @@ import org.springframework.stereotype.Repository
 interface PointJpaRepository : JpaRepository<Point, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     fun findForUpdateByUserId(userId: Long): Point?
+
+    @Lock(LockModeType.OPTIMISTIC)
+    fun findWithOptimisticLockByUserId(userId: Long): Point?
 }

--- a/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/PointRepositoryImpl.kt
+++ b/src/main/kotlin/kr/hhplus/be/server/infrastructure/point/PointRepositoryImpl.kt
@@ -10,7 +10,8 @@ class PointRepositoryImpl @Autowired constructor(
     private val pointJpaRepository: PointJpaRepository,
 ) : PointRepository {
     override fun findPointByUserIdWithLock(userId: Long): Point? {
-        return pointJpaRepository.findForUpdateByUserId(userId)
+//        return pointJpaRepository.findForUpdateByUserId(userId)
+        return pointJpaRepository.findWithOptimisticLockByUserId(userId)
     }
 
     override fun save(point: Point): Point {

--- a/src/test/kotlin/kr/hhplus/be/server/application/OrderApplicationTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/application/OrderApplicationTest.kt
@@ -27,7 +27,7 @@ class OrderApplicationTest {
     private val sut = OrderApplication(orderService, productService, couponService, pointService)
 
     @Test
-    fun `given 쿠폰이 있을 때 when 주문 시 then 쿠폰 사용이 호출된다`() {
+    fun `쿠폰이 있을 경우, 주문 시, 쿠폰 사용이 호출된다`() {
         //given
         val userId = 1L
         val couponId = 1L

--- a/src/test/kotlin/kr/hhplus/be/server/application/ProductApplicationTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/application/ProductApplicationTest.kt
@@ -18,7 +18,7 @@ class ProductApplicationTest {
     private val productApplication = ProductApplication(productService, orderProductService)
 
     @Test
-    fun `given 상태에 대한 검색 조건이 없이 when 상품 조회 시 then 두 상태 모두 조회된다`() {
+    fun `상태에 대한 검색 조건이 없는 경우, 상품 조회 시, 두 상태 모두 조회된다`() {
         //given
         val products = listOf(
             Product(
@@ -47,7 +47,7 @@ class ProductApplicationTest {
     }
 
     @Test
-    fun `given 상태에 대한 검색 조건이 AVAILABLE이고 when 상품 조회 시 then 유효한 상품만 조회된다`() {
+    fun `상태에 대한 검색 조건이 AVAILABLE인 경우, 상품 조회 시, 유효한 상품만 조회된다`() {
         //given
         val products = listOf(
             Product(
@@ -77,7 +77,7 @@ class ProductApplicationTest {
 
 
     @Test
-    fun `given 상태에 대한 검색 조건이 UNAVAILABLE이고 when 상품 조회 시 then 유효하지 않은 상품만 조회된다`() {
+    fun `상태에 대한 검색 조건이 UNAVAILABLE인 경우, 상품 조회 시, 유효하지 않은 상품만 조회된다`() {
         //given
         val products = listOf(
             Product(

--- a/src/test/kotlin/kr/hhplus/be/server/domain/coupon/CouponServiceTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/coupon/CouponServiceTest.kt
@@ -21,7 +21,7 @@ class CouponServiceTest {
     private val sut: CouponService = CouponService(couponTemplateRepository, issuedCouponRepository)
 
     @Test
-    fun `given 쿠폰 목록이 없는 사용자인 경우 when 쿠폰 목록 조회 시 then 빈 리스트를 반환한다`() {
+    fun `쿠폰 목록이 없는 사용자인 경우, 쿠폰 목록 조회 시, 빈 리스트를 반환한다`() {
         //given
         val userId = 1L
         given(issuedCouponRepository.findIssuedCouponsByUserId(userId)).willReturn(emptyList())
@@ -34,7 +34,7 @@ class CouponServiceTest {
     }
 
     @Test
-    fun `given 쿠폰 목록이 있는 사용자인 경우 when 쿠폰 목록 조회 시 then 쿠폰 목록을 반환한다`() {
+    fun `쿠폰 목록이 있는 사용자인 경우, 쿠폰 목록 조회 시, 쿠폰 목록을 반환한다`() {
         //given
         val userId = 1L
         val now = LocalDateTime.of(2025, 1, 8, 1, 0, 0)
@@ -67,7 +67,7 @@ class CouponServiceTest {
     }
 
     @Test
-    fun `given 존재하지 않는 쿠폰 템플릿 id인 경우 when 쿠폰 발급 시 then CustomException을 반환한다`() {
+    fun `존재하지 않는 쿠폰 템플릿 id인 경우, 쿠폰 발급 시, CustomException이 발생한다`() {
         //given
         val templateId = 0L
         val userId = 1L
@@ -83,7 +83,7 @@ class CouponServiceTest {
     }
 
     @Test
-    fun `given when 쿠폰 발급 시 then 쿠폰이 발급된다`() {
+    fun `쿠폰 발급 시, 쿠폰이 발급된다`() {
         //given
         val templateId = 1L
         val userId = 1L
@@ -124,7 +124,7 @@ class CouponServiceTest {
     }
 
     @Test
-    fun `given 존재하지 않는 쿠폰 id인 경우 when 쿠폰 사용 시 then CustomException을 반환한다`() {
+    fun `존재하지 않는 쿠폰 id인 경우, 쿠폰 사용 시, CustomException이 발생한다`() {
         //given
         val couponId = 0L
         val userId = 1L

--- a/src/test/kotlin/kr/hhplus/be/server/domain/coupon/model/CouponTemplateTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/coupon/model/CouponTemplateTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertFailsWith
 
 class CouponTemplateTest {
     @Test
-    fun `given 쿠폰 템플릿의 발급 개수가 최대 발급 개수와 같은 경우 when 쿠폰 발급 시 then CustomException이 발생한다` () {
+    fun `쿠폰 템플릿의 발급 개수가 최대 발급 개수와 같은 경우, 쿠폰 발급 시, CustomException이 발생한다` () {
         //given
         val userId = 1L
         val num = 10
@@ -39,7 +39,7 @@ class CouponTemplateTest {
     }
 
     @Test
-    fun `given 쿠폰 템플릿의 발급 기한이 지난 경우 when 쿠폰 발급 시 then CustomException이 발생한다`() {
+    fun `쿠폰 템플릿의 발급 기한이 지난 경우, 쿠폰 발급 시, CustomException이 발생한다`() {
         //given
         val userId = 1L
         val num = 10
@@ -68,7 +68,7 @@ class CouponTemplateTest {
     }
 
     @Test
-    fun `given when 쿠폰 발급 시 then 365일 이후 만료되는 쿠폰이 발급된다`() {
+    fun `쿠폰 발급 시, 365일 이후 만료되는 쿠폰이 발급된다`() {
         //given
         val userId = 1L
         val now = LocalDateTime.of(2025, 1, 8, 1, 0, 0)

--- a/src/test/kotlin/kr/hhplus/be/server/domain/coupon/model/IssuedCouponTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/coupon/model/IssuedCouponTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.assertFailsWith
 
 class IssuedCouponTest {
     @Test
-    fun `given 사용일시가 존재하는 경우 when 상태 조회 시 then 사용 완료로 반환하다`() {
+    fun `사용일시가 존재하는 경우, 상태 조회 시, 사용 완료를 반환하다`() {
         //given
         val now = LocalDateTime.of(2025, 1, 8, 1, 0, 0)
         val template = CouponTemplate(
@@ -38,7 +38,7 @@ class IssuedCouponTest {
     }
 
     @Test
-    fun `given 사용일시가 없고, 사용기한이 지난 경우 when 상태 조회 시 기한 만료를 반환한다`() {
+    fun `사용일시가 없고, 사용기한이 지난 경우, 상태 조회 시, 기한 만료를 반환한다`() {
         //given
         val now = LocalDateTime.of(2025, 1, 8, 1, 0, 0)
         val template = CouponTemplate(
@@ -67,7 +67,7 @@ class IssuedCouponTest {
     }
 
     @Test
-    fun `given 사용일시가 없고, 사용기간이 지나지 않은 경우 when 상태 조회 시 then 사용 가능을 반환한다`() {
+    fun `사용일시가 없고, 사용기간이 지나지 않은 경우, 상태 조회 시, 사용 가능을 반환한다`() {
         //given
         val now = LocalDateTime.of(2025, 1, 8, 1, 0, 0)
         val template = CouponTemplate(
@@ -96,7 +96,7 @@ class IssuedCouponTest {
     }
 
     @Test
-    fun `given 주문자와 쿠폰 소유자가 일치하지 않는 경우 when 쿠폰 사용 시 then CustomException을 반환한다`() {
+    fun `주문자와 쿠폰 소유자가 일치하지 않는 경우, 쿠폰 사용 시, CustomException이 발생한다`() {
         //given
         val ownerId = 1L
         val userId = 2L
@@ -129,7 +129,7 @@ class IssuedCouponTest {
     }
 
     @Test
-    fun `given 쿠폰이 사용가능하지 않은 경우 when 쿠폰 사용 시 then CustomException을 반환한다`() {
+    fun `쿠폰이 사용가능하지 않은 경우, 쿠폰 사용 시, CustomException이 발생한다`() {
         //given
         val ownerId = 1L
         val userId = 1L

--- a/src/test/kotlin/kr/hhplus/be/server/domain/order/OrderProductRepositoryTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/order/OrderProductRepositoryTest.kt
@@ -18,7 +18,7 @@ class OrderProductRepositoryTest @Autowired constructor(
     private val sut: OrderProductRepository,
 ) {
     @Test
-    fun `given 7일 전, 3일 전, 지금 주문이 이뤄졌을 때 when 기간 내 인기 상품 주문량 조회 시 then 기간 내 판매량 상위 5건이 반환된다`() {
+    fun `7일 전, 3일 전, 지금 주문이 이루어진 경우, 기간 내 인기 상품 주문량 조회 시, 기간 내 판매량 상위 5건이 반환된다`() {
         //given
         val now = LocalDateTime.of(2025, 1, 10, 0, 0, 0)
         val expected = listOf(

--- a/src/test/kotlin/kr/hhplus/be/server/domain/order/OrderProductServiceTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/order/OrderProductServiceTest.kt
@@ -14,7 +14,7 @@ class OrderProductServiceTest {
     private val sut = OrderProductService(orderProductRepository)
 
     @Test
-    fun `given when 인기 상품 목록 조회 시 then 인기 상품 목록을 반환한다`() {
+    fun `인기 상품 목록 조회 시, 인기 상품 목록을 반환한다`() {
         //given
         val expected = listOf(
             OrderProductQuantitySumInfo(1L, 5L),
@@ -36,7 +36,7 @@ class OrderProductServiceTest {
     }
 
     @Test
-    fun `given 검색 시작 시점이 검색 종료 시점보다 늦고 when 인기 상품 목록 조회 시 then IllegalArgumentException이 발생한다`() {
+    fun `검색 시작 시점이 검색 종료 시점보다 늦은 경우, 인기 상품 목록 조회 시, IllegalArgumentException이 발생한다`() {
         //given
         val start = LocalDateTime.of(2025, 1, 10, 0, 0)
         val end = LocalDateTime.of(2025, 1, 1, 0, 0)

--- a/src/test/kotlin/kr/hhplus/be/server/domain/order/OrderRepositoryTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/order/OrderRepositoryTest.kt
@@ -18,7 +18,7 @@ class OrderRepositoryTest @Autowired constructor(
     val sut : OrderRepository,
 ) {
     @Test
-    fun `given 주문 정보 when 주문 저장 시 then 주문 상품 목록도 저장된다`() {
+    fun `주문 정보가 주어진 경우, 주문 저장 시, 주문 상품 목록도 저장된다`() {
         //given
         val order = Order(
             id = 0L,

--- a/src/test/kotlin/kr/hhplus/be/server/domain/order/OrderServiceTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/order/OrderServiceTest.kt
@@ -14,7 +14,7 @@ class OrderServiceTest {
     private val sut = OrderService(orderRepository)
 
     @Test
-    fun `given when 주문 생성 시 then 주문이 반환된다`() {
+    fun `주문 생성 시, 주문이 반환된다`() {
         //given
         val userId = 1L
         val coupon = null

--- a/src/test/kotlin/kr/hhplus/be/server/domain/order/model/OrderTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/order/model/OrderTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertFailsWith
 class OrderTest {
 
     @Test
-    fun `given 주문상품목록이 비어있으면 when 주문 생성 시 then IllegalArgumentException이 발생된다`() {
+    fun `주문 상품 목록이 빈 경우, 주문 생성 시, IllegalArgumentException이 발생한다`() {
         //given
         val orderProducts = emptyList<OrderProduct>()
         val userId = 1L
@@ -28,7 +28,7 @@ class OrderTest {
     }
 
     @Test
-    fun `given 주문수량이 0이면 when 주문 생성 시 then IllegalArgumentException이 발생된다`() {
+    fun `주문수량이 0인 경우, 주문 생성 시, IllegalArgumentException이 발생한다`() {
         //given
         val orderProducts = listOf(
             OrderProduct(
@@ -54,7 +54,7 @@ class OrderTest {
     }
 
     @Test
-    fun `given 쿠폰 소유자와 주문자가 다른 경우 when 주문 생성 시 IllegalArgumentException이 발생한다`() {
+    fun `쿠폰 소유자와 주문자가 다른 경우, 주문 생성 시, IllegalArgumentException이 발생한다`() {
         //given
         val orderProducts = listOf(
             OrderProduct(
@@ -98,7 +98,7 @@ class OrderTest {
     }
 
     @Test
-    fun `given 상품 목록과 쿠폰으로 when 주문 생성 시 then 주문 금액과 결제 금액이 계산되고, 쿠폰이 사용처리된다`() {
+    fun `상품 목록과 쿠폰이 주어진 경우, 주문 생성 시, 주문 금액과 결제 금액이 계산되고 쿠폰이 사용처리된다`() {
         //given
         val userId = 1L
         val discountRate = 10
@@ -144,7 +144,7 @@ class OrderTest {
     }
 
     @Test
-    fun `given 상품 목록으로 when 주문 생성 시 then 주문 금액과 결제 금액이 동일하다`() {
+    fun `상품 목록이 주어진 경우, 주문 생성 시, 주문 금액과 결제 금액이 동일하다`() {
         //given
         val userId = 1L
         val coupon = null

--- a/src/test/kotlin/kr/hhplus/be/server/domain/point/PointServiceTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/point/PointServiceTest.kt
@@ -13,7 +13,7 @@ class PointServiceTest {
     private val sut: PointService = PointService(pointRepository)
 
     @Test
-    fun `given 포인트 정보가 없는 사용자, when 포인트 조회 시 then 잔액이 0인 포인트를 반환한다`() {
+    fun `포인트 정보가 없는 사용자인 경우, 포인트 조회 시, 잔액이 0인 포인트를 반환한다`() {
         //given
         val userId = 1L
         given(pointRepository.findPointByUserIdWithLock(userId)).willReturn(null)
@@ -27,7 +27,7 @@ class PointServiceTest {
     }
 
     @Test
-    fun `given 포인트 정보가 있는 사용자 when 포인트 조회 시 then 해당 사용자의 포인트를 반환한다`() {
+    fun `포인트 정보가 있는 사용자인 경우, 포인트 조회 시, 해당 사용자의 포인트를 반환한다`() {
         //given
         val userId = 1L
         val balance = 500
@@ -42,7 +42,7 @@ class PointServiceTest {
     }
 
     @Test
-    fun `given 사용자와 충전 금액 when 포인트 충전 시 then 충전된 포인트를 반환한다`() {
+    fun `사용자와 충전 금액이 주어진 경우, 포인트 충전 시, 충전된 포인트를 반환한다`() {
         //given
         val userId = 1L
         val balance = 300
@@ -58,7 +58,7 @@ class PointServiceTest {
     }
 
     @Test
-    fun `given 사용자와 충전 금액 when 포인트 사용 시 then 사용 후 포인트를 반환한다`() {
+    fun `사용자와 충전 금액이 주어진 경우, 포인트 사용 시, 사용 후 포인트를 반환한다`() {
         //given
         val userId = 1L
         val balance = 500

--- a/src/test/kotlin/kr/hhplus/be/server/domain/point/model/PointTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/point/model/PointTest.kt
@@ -12,7 +12,7 @@ import kotlin.test.assertFailsWith
 class PointTest () {
 
     @Test
-    fun `given 잔액이 최솟값 미만인 when 포인트 생성 시 then IllegalArgumentException이 발생한다`() {
+    fun `잔액이 최솟값 미만인 경우, 포인트 생성 시, IllegalArgumentException이 발생한다`() {
         //given
 
         //when
@@ -28,7 +28,7 @@ class PointTest () {
     }
 
     @Test
-    fun `given 잔액이 최댓값 초과인 when 포인트 생성 시 then IllegalArgumentException이 발생한다`() {
+    fun `잔액이 최댓값 초과인 경우, 포인트 생성 시, IllegalArgumentException이 발생한다`() {
         //given
 
         //when
@@ -44,7 +44,7 @@ class PointTest () {
     }
 
     @Test
-    fun `given 충전 금액이 최솟값 미만이고 when 포인트 충전 시 then CustomException이 발생한다`() {
+    fun `충전 금액이 최솟값 미만인 경우, 포인트 충전 시, CustomException이 발생한다`() {
         //given
         val amount = Point.MIN_AMOUNT-1
         val point = Point(
@@ -65,7 +65,7 @@ class PointTest () {
     }
 
     @Test
-    fun `given 충전 금액이 백만 초과이고 when 포인트 충전 시 then CustomException이 발생한다`() {
+    fun `충전 금액이 백만 초과인 경우, 포인트 충전 시, CustomException이 발생한다`() {
         //given
         val amount = Point.MAX_AMOUNT+1
         val point = Point(
@@ -86,7 +86,7 @@ class PointTest () {
     }
 
     @Test
-    fun `given 잔액이 1이고 when 충전 후 잔액이 백만 초과이면 then CustomException이 발생한다`() {
+    fun `잔액이 1이고 충전 후 잔액이 백만 초과인 경우, 포인트 충전 시, CustomException이 발생한다`() {
         //given
         val point = Point(
             id = 0L,
@@ -105,7 +105,7 @@ class PointTest () {
     }
 
     @Test
-    fun `given 차감 금액이 0이하이고 when 포인트 차감 시 then IllegalArgumentException이 발생한다`() {
+    fun `차감 금액이 0이하인 경우, 포인트 차감 시, IllegalArgumentException이 발생한다`() {
         //given
         val amount = 0
         val point = Point(
@@ -125,7 +125,7 @@ class PointTest () {
     }
 
     @Test
-    fun `given 차감 금액이 잔액보다 크고 when 포인트 차감 시 then CustomException이 발생한다`() {
+    fun `차감 금액이 잔액보다 큰 경우, 포인트 차감 시, CustomException이 발생한다`() {
         //given
         val balance = 100
         val amount = balance + 1

--- a/src/test/kotlin/kr/hhplus/be/server/domain/product/ProductRepositoryTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/product/ProductRepositoryTest.kt
@@ -18,7 +18,7 @@ class ProductRepositoryTest @Autowired constructor(
     val sut : ProductRepository
 ) {
     @Test
-    fun `given when 잔여수량이 0보다 큰 상품 조회 시 then 잔여수량이 0보다 큰 상품 목록을 반환한다`() {
+    fun `잔여수량이 0보다 큰 상품 조회 시, 잔여수량이 0보다 큰 상품 목록을 반환한다`() {
         //given
 
         //when
@@ -32,7 +32,7 @@ class ProductRepositoryTest @Autowired constructor(
     }
 
     @Test
-    fun `given when 잔여수량이 0이하인 상품 조회 시 then 잔여수량이 0이하인 상품 목록을 반환한다`() {
+    fun `잔여수량이 0이하인 상품 조회 시, 잔여수량이 0이하인 상품 목록을 반환한다`() {
         //given
 
         //when

--- a/src/test/kotlin/kr/hhplus/be/server/domain/product/ProductServiceTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/product/ProductServiceTest.kt
@@ -21,7 +21,7 @@ class ProductServiceTest {
     private val sut: ProductService = ProductService(productRepository)
 
     @Test
-    fun `given 존재하지 않는 상품id when 상품 조회 시 then IllegalArgumentException을 반환한다`() {
+    fun `존재하지 않는 상품id인 경우, 상품 조회 시, IllegalArgumentException이 발생한다`() {
         //given
         given(productRepository.findProductById(any())).willReturn(null)
 
@@ -34,7 +34,7 @@ class ProductServiceTest {
     }
 
     @Test
-    fun `given when 상품 목록 조회 시 then 목록을 반환한다`() {
+    fun `상품 목록 조회 시, 목록을 반환한다`() {
         //given
         val pageRequest = PageRequest.of(0, 10)
         val page = PageImpl<Product>(
@@ -58,7 +58,7 @@ class ProductServiceTest {
     }
 
     @Test
-    fun `given 조회 조건으로 Available이 주어지고 when 상품 목록 조회 시 then Available한 상품 목록을 반환한다`() {
+    fun `조회 조건으로 Available이 주어진 경우, 상품 목록 조회 시, Available한 상품 목록을 반환한다`() {
         //given
         val status = ProductStatus.AVAILABLE
         val availableProducts = PageImpl<Product>(
@@ -93,7 +93,7 @@ class ProductServiceTest {
     }
 
     @Test
-    fun `given 조회 조건으로 Unavabilable 주어지고 when 상품 목록 조회 시 then Unavabilable한 상품 목록을 반환한다`() {
+    fun `조회 조건으로 Unavailable이 주어진 경우, 상품 목록 조회 시, Unavailable한 상품 목록을 반환한다`() {
         //given
         val status = ProductStatus.UNAVAILABLE
         val availableProducts = PageImpl<Product>(
@@ -128,7 +128,7 @@ class ProductServiceTest {
     }
 
     @Test
-    fun `given 존재하지 않는 상품에 대해 when 상품 잔여 수량 감소 시 then CustomException 이 발생한다`() {
+    fun `존재하지 않는 상품인 경우, 상품 잔여 수량 감소 시, CustomException이 발생한다`() {
         //given
         val id = 0L
         given(productRepository.findProductByIdWithLock(id)).willReturn(null)

--- a/src/test/kotlin/kr/hhplus/be/server/domain/product/model/ProductTest.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/domain/product/model/ProductTest.kt
@@ -11,7 +11,7 @@ import kotlin.test.assertFailsWith
 class ProductTest {
 
     @Test
-    fun `given 상품의 잔여 수량이 0 이하인 when 상품 상태 조회 시 then 상품 상태는 UNAVAILABLE을 반환한다`() {
+    fun `상품의 잔여 수량이 0 이하인 경우, 상품 상태 조회 시, 상품 상태는 UNAVAILABLE을 반환한다`() {
         //given
         val product = Product(
             id = 1L,
@@ -30,7 +30,7 @@ class ProductTest {
     }
 
     @Test
-    fun `given 상품의 잔여 수량이 0 초과인 when 상품 상태 조회 시 then 상품 상태는 AVAILABLE을 반환한다`() {
+    fun `상품의 잔여 수량이 0 초과인 경우, 상품 상태 조회 시, 상품 상태는 AVAILABLE을 반환한다`() {
         //given
         val product = Product(
             id = 1L,
@@ -49,7 +49,7 @@ class ProductTest {
     }
 
     @Test
-    fun `given 상품 가격이 100 단위가 아닌 when 상품 생성 시 then IllegalArgumentException이 발생한다`() {
+    fun `상품 가격이 100 단위가 아닌 경우, 상품 생성 시, IllegalArgumentException이 발생한다`() {
         //given
         val unitPrice = 150
 
@@ -69,7 +69,7 @@ class ProductTest {
     }
 
     @Test
-    fun `given 상품 가격이 100 단위인 when  상품 생성 시 then 성공한다`() {
+    fun `상품 가격이 100 단위인 경우, 상품 생성 시, 성공한다`() {
         //given
         val unitPrice = 100
 
@@ -88,7 +88,7 @@ class ProductTest {
     }
 
     @Test
-    fun `given 잔여 수량를 초과해서 when 상품 수량 감소 시 then CustomException 이 발생한다`() {
+    fun `잔여 수량를 초과한 경우, 상품 수량 감소 시, CustomException이 발생한다`() {
         //given
         val remainingQuantity = 5
         val amount = remainingQuantity + 1
@@ -110,7 +110,7 @@ class ProductTest {
     }
 
     @Test
-    fun `given 잔여 수량 이하로 when 상품 수량 감소 시 then 상품의 수량이 감소된다`() {
+    fun `잔여 수량 이하인 경우, 상품 수량 감소 시, 상품의 수량이 감소된다`() {
         //given
         val remainingQuantity = 5
         val amount = remainingQuantity

--- a/src/test/kotlin/kr/hhplus/be/server/integration/CouponServiceIntegrationTests.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/integration/CouponServiceIntegrationTests.kt
@@ -53,7 +53,7 @@ class CouponServiceIntegrationTests @Autowired constructor(
     }
 
     @Test
-    fun `쿠폰 사용 요청이 2건 이상 들어왔을 때, 1건만 성공한다`() {
+    fun `쿠폰 사용 요청이 2건이 들어왔을 때, 1건만 성공한다`() {
         //given
         val numOfIterations = 2
         val couponId = 1L

--- a/src/test/kotlin/kr/hhplus/be/server/integration/CouponServiceIntegrationTests.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/integration/CouponServiceIntegrationTests.kt
@@ -2,11 +2,13 @@ package kr.hhplus.be.server.integration
 
 import kr.hhplus.be.server.domain.coupon.CouponService
 import org.junit.jupiter.api.assertAll
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.system.measureTimeMillis
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -14,6 +16,7 @@ import kotlin.test.assertEquals
 class CouponServiceIntegrationTests @Autowired constructor(
     val sut: CouponService
 ) {
+    val logger = LoggerFactory.getLogger(javaClass)
 
     @Test
     fun `쿠폰 최대 발급 개수가 10개이고, 쿠폰 발급 요청이 20건 들어왔을 때, 10건만 성공한다`() {
@@ -61,22 +64,25 @@ class CouponServiceIntegrationTests @Autowired constructor(
         val successCount = AtomicInteger(0)
         val failCount = AtomicInteger(0)
 
-        //when
-        for (i in 1..numOfIterations) {
-            executorService.execute {
-                try {
-                    sut.use(couponId, userId)
-                    successCount.getAndIncrement()
-                } catch(e: Exception) {
-                    failCount.getAndIncrement()
-                } finally {
-                    doneSignal.countDown()
+        val measuredTime = measureTimeMillis {
+            //when
+            for (i in 1..numOfIterations) {
+                executorService.execute {
+                    try {
+                        sut.use(couponId, userId)
+                        successCount.getAndIncrement()
+                    } catch(e: Exception) {
+                        failCount.getAndIncrement()
+                    } finally {
+                        doneSignal.countDown()
+                    }
                 }
             }
-        }
 
-        doneSignal.await()
-        executorService.shutdown()
+            doneSignal.await()
+            executorService.shutdown()
+        }
+        logger.info("소요 시간 : $measuredTime")
 
         //then
         assertAll(

--- a/src/test/kotlin/kr/hhplus/be/server/integration/PointServiceIntegrationTests.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/integration/PointServiceIntegrationTests.kt
@@ -26,6 +26,7 @@ class PointServiceIntegrationTests @Autowired constructor(
 
         val executorService = Executors.newFixedThreadPool(numOfIterations)
         val doneSignal = CountDownLatch(numOfIterations)
+        val balance = AtomicInteger(1000)
         val successCount = AtomicInteger(0)
         val failCount = AtomicInteger(0)
 
@@ -35,6 +36,7 @@ class PointServiceIntegrationTests @Autowired constructor(
                 try {
                     sut.charge(userId, chargeRequests[i-1])
                     successCount.getAndIncrement()
+                    balance.getAndAdd(chargeRequests[i-1])
                 } catch(e: Exception) {
                     failCount.getAndIncrement()
                 } finally {
@@ -48,6 +50,7 @@ class PointServiceIntegrationTests @Autowired constructor(
                 try {
                     sut.use(userId, useRequests[i-1])
                     successCount.getAndIncrement()
+                    balance.getAndAdd(-1 * useRequests[i-1])
                 } catch(e: Exception) {
                     failCount.getAndIncrement()
                 } finally {
@@ -63,8 +66,8 @@ class PointServiceIntegrationTests @Autowired constructor(
 
         //then
         assertAll(
-            { assertEquals(numOfIterations, successCount.get()) },
-            { assertEquals(1000 + chargeRequests.sum() - useRequests.sum(), result.balance) },
+            { assertEquals(numOfIterations, successCount.get() + failCount.get()) },
+            { assertEquals(balance.get(), result.balance) },
         )
     }
 }

--- a/src/test/kotlin/kr/hhplus/be/server/integration/PointServiceIntegrationTests.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/integration/PointServiceIntegrationTests.kt
@@ -2,11 +2,13 @@ package kr.hhplus.be.server.integration
 
 import kr.hhplus.be.server.domain.point.PointService
 import org.junit.jupiter.api.assertAll
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
+import kotlin.system.measureTimeMillis
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -14,6 +16,7 @@ import kotlin.test.assertEquals
 class PointServiceIntegrationTests @Autowired constructor(
     private val sut: PointService,
 ) {
+    val logger = LoggerFactory.getLogger(javaClass)
 
     @Test
     fun `포인트 충전 및 차감 요청이 각 5건씩 들어왔을 때, 최종 금액은 각 충전 및 차감 금액을 계산한 결과이다`() {
@@ -30,37 +33,40 @@ class PointServiceIntegrationTests @Autowired constructor(
         val successCount = AtomicInteger(0)
         val failCount = AtomicInteger(0)
 
-        //when
-        for (i in 1..chargeRequests.size) {
-            executorService.execute {
-                try {
-                    sut.charge(userId, chargeRequests[i-1])
-                    successCount.getAndIncrement()
-                    balance.getAndAdd(chargeRequests[i-1])
-                } catch(e: Exception) {
-                    failCount.getAndIncrement()
-                } finally {
-                    doneSignal.countDown()
+        val measuredTime = measureTimeMillis {
+            //when
+            for (i in 1..chargeRequests.size) {
+                executorService.execute {
+                    try {
+                        sut.charge(userId, chargeRequests[i-1])
+                        successCount.getAndIncrement()
+                        balance.getAndAdd(chargeRequests[i-1])
+                    } catch(e: Exception) {
+                        failCount.getAndIncrement()
+                    } finally {
+                        doneSignal.countDown()
+                    }
                 }
             }
-        }
 
-        for (i in 1..useRequests.size) {
-            executorService.execute {
-                try {
-                    sut.use(userId, useRequests[i-1])
-                    successCount.getAndIncrement()
-                    balance.getAndAdd(-1 * useRequests[i-1])
-                } catch(e: Exception) {
-                    failCount.getAndIncrement()
-                } finally {
-                    doneSignal.countDown()
+            for (i in 1..useRequests.size) {
+                executorService.execute {
+                    try {
+                        sut.use(userId, useRequests[i-1])
+                        successCount.getAndIncrement()
+                        balance.getAndAdd(-1 * useRequests[i-1])
+                    } catch(e: Exception) {
+                        failCount.getAndIncrement()
+                    } finally {
+                        doneSignal.countDown()
+                    }
                 }
             }
-        }
 
-        doneSignal.await()
-        executorService.shutdown()
+            doneSignal.await()
+            executorService.shutdown()
+        }
+        logger.info("소요 시간 : $measuredTime ($successCount, $failCount)")
 
         val result = sut.getPointByUserId(userId)
 

--- a/src/test/kotlin/kr/hhplus/be/server/integration/ProductServiceIntegrationTests.kt
+++ b/src/test/kotlin/kr/hhplus/be/server/integration/ProductServiceIntegrationTests.kt
@@ -18,7 +18,7 @@ class ProductServiceIntegrationTests @Autowired constructor(
 ) {
 
     @Test
-    fun `상품 재고 요청이 30건 들어왔을 때, 요청 내용만큼 재고가 차감된다`() {
+    fun `상품 재고 요청이 5건 들어왔을 때, 요청 내용만큼 재고가 차감된다`() {
         //given
         val numOfIterations = 5
 


### PR DESCRIPTION
# **커밋 링크**
## Step 11
- [📝 docs : 시나리오별 동시성 제어 방안에 대한 보고서 작성](https://github.com/yoon-chaejin/hhplus-ecommerce-service/commit/ad6ddbc5bdcba69d47fc2c8e04bea5a7201fce6e)

## Step 12
- [✨ feature: 쿠폰 사용 시 낙관적 락 적용](https://github.com/yoon-chaejin/hhplus-ecommerce-service/commit/1e8d5862d182c36b0f57336084bd03dbec8f41ec)
- [✨ feature: 포인트 충전-차감 시 낙관적 락 적용](https://github.com/yoon-chaejin/hhplus-ecommerce-service/commit/0bc2508bd5887e7cdfee179d3d89332f5ddee33f)

---

# **리뷰 포인트(질문)**
- 팀원들과 논의하면서, 낙관적 락이 아래와 같이 동작한다고 분석했습니다. 비관적 락은 DB단에서 오류가 발생하는 반면, 낙관적 락은 Application 단에서 오류라고 판단하는 게 맞는지 확인 요청 드립니다.
```
T1 -> SELECT * FROM users WHERE userId = 1;
T2 -> SELECT * FROM users WHERE userId = 1;
T1 -> UPDATE users SET point = 700, version = 1 WHERE userId = 1 AND version = 0;
T1 COMMIT;
# T1 은 성공!

T2 -> UPDATE users SET point = 1000, version = 1 WHERE userId = 1 AND version = 0;
# DB에서 return 0

# Spring Data 단에서 Update 0 이라 ObjectOptimisticLockingFailureException 발생
# 재시도 처리하거나 오류나서 Rollback 되거나 하도록 Application 단에서 제어
```
- 동시성 제어 방안에 대해서 찾다보니 "Named(=Custom) Query + `@Modifying`" 방식으로 동시성 문제를 해결하는 경우를 확인했습니다.
예를 들어, 쿠폰 사용 시나리오에서 현재는 1) 조회 2) 사용가능여부 확인 3) 변경을 Application 에서 진행하고 있는데, 이를 Update 쿼리롤 한 번에 사용처리를 하는 방식으로 이해했습니다. 
(`UPDATE issued_coupon SET usedAt = :at WHERE ownedBy = :userId AND usedAt IS NULL AND expiresAt < :at`)
DB쿼리에 도메인 정책이 강하게 결합된다는 점에서 이번에는 사용하지 않았지만, 쿠폰 사용 가능 여부와 같은 정책이 빈번하게 변경되지 않고, 영향도가 Service 레이어에서 제어된다는 점에서 고려해볼 만하다고 생각했습니다. 이런 방안에 대해 어떻게 생각하시는지, 추가로 고려해봐야 하는 영향도/리스크가 있는지 궁금합니다.